### PR TITLE
v0.3.0

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,5 +1,13 @@
 # node-pg-rev-gen - Revision History
 
+- 2022-08-09: v0.3.0
+  - Removed rev_current and rev_current_all views
+  - Changed _current_all_view to current_all_mview
+    -  When not materialized due to config, this includes the _with_rev views to limit joins across views
+  - Removed _with_rev views and rolled rev columns in to base views
+  - Syntax fixes for materialized views
+  - Added doNotMaterialize flag for extracted fields to omit them from the materialized table to save space
+
 - 2022-08-01: v0.2.1
   - Fix typo in _rev_load template
 

--- a/README.md
+++ b/README.md
@@ -21,12 +21,11 @@ The following objects are generated:
   - xxx_rev - Table containing a history of all of the changes to the raw data
     - xxx_rev_load() - Generates new revisions based on updated load data
     - xxx_rev_trim() - Removes raw data from old notes (can be recovered via the delta fields)
-    - xxx_rev_current - View showing xxx_rev but only for the current, not-deleted records
-  - xxx_current_view - A view containing the basic metadata and specified projected columns from the current data
-    - xxx_current - An optionally materialized view of xxx_current_view
-    - xxx_current_refresh() - A procedure to refresh the current view (created even if current is not materialized)
-    - xxx_current_with_rev - A view of xxx_current joined to xxx_rev to include raw data and other additional metadta
-  - xxx_updated - A table to track an update date for each record - generally used to sink webhook notifications of updates but can also be used to force updates of specific records
+  - xxx_current_all_mview - An (optionally materialized) view of all current records (including deleted records)
+    - xxx_current_refresh() - A procedure to refresh the materialized view (created even if current is not materialized for consistency)
+    - XXX_current_all - All current records with non-materialized extracted columns added
+    - XXX_current_view - Same as XXX_current_view but with deleted records filtered
+  - xxx_updated - A table to track external updates for each record - generally used to sink webhook notifications of updates but can also be used to force updates of specific records
     - xxx_updated_load() - Procedure to load a batch of records into xxx_updated
     - xxx_updated_trim() - Procedure to delete updates older than a given date
 
@@ -51,6 +50,7 @@ The following objects are generated:
   - updaters - String of users and roles to grant SELECT and EXECUTE access to this type
   - extractedFields - A hash of information on fields to extract into xxx_current
     - [name] - The column name in the DB
+    - doNotMaterialize - If true, the column is omitted from materialized views to save space
     - definition - The SQL table definition for the column
     - index - If true, index this column (only if materialized)
     - unique - If true, make the index unique (only if materialized and index)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@msamblanet/node-pg-rev-gen",
-  "version": "0.2.1",
+  "version": "0.3.0",
   "description": "SQL generator for the node-pg-rev system",
   "author": "Michael Samblanet <michael@samblanet.com>",
   "license": "Apache-2.0",

--- a/src/views/partials/current.hbs
+++ b/src/views/partials/current.hbs
@@ -1,90 +1,98 @@
 --
--- View of the current data in the system (extranious fields stripped out - join to _rev or _raw if needed)
+-- Materialized view of current_view_all to allow for indexing
 --
-CREATE OR REPLACE VIEW {{namespace}}{{name}}_current_all_view AS
+{{#if materializeView}}CREATE MATERIALIZED VIEW IF NOT EXISTS{{else}}CREATE OR REPLACE VIEW{{/if}} {{namespace}}{{name}}_current_all_mview AS
 SELECT rev_id,
        ext_uid,
        {{#if storeSource}}source_id,{{/if}}
        {{#if extIdType}}ext_id,{{/if}}
-       -- Begin custom fields
+       -- Begin materialized custom fields
+{{#if materializeView}}
+{{~#each extractedFields}}{{#if this.definition}}{{#unless this.doNotMaterialize}}
+      {{this.definition}} AS {{@key}}, {{#if this.comment}}-- {{this.comment}}{{/if}}
+{{/unless}}{{/if}}{{/each}}
+{{else}}
 {{~#each extractedFields}}{{#if this.definition}}
       {{this.definition}} AS {{@key}}, {{#if this.comment}}-- {{this.comment}}{{/if}}
 {{/if}}{{/each}}
+{{/if}}
        -- End custom fields
        deleted,
        update_date
-  FROM {{namespace}}{{name}}_rev_current_all;
+{{#unless materializeView}}
+       -- If the view is not materialized, just bring in all the extra columns now...
+       , data_rev, raw_data, raw_delta, raw_revert, fetch_date, ext_create_date, ext_update_date, create_date
+{{/unless}}
+  FROM {{namespace}}{{name}}_rev WHERE current;
 
 {{#if materializeView}}
---
--- Materialized view of current_view_all to allow for indexing
---
-CREATE MATERIALIZED VIEW IF NOT EXISTS {{namespace}}{{name}}_current_all AS
-SELECT * FROM {{namespace}}{{name}}_current_all_view;
-
 -- rev_id and ext_uid should be unique so give them unique indexes
-CREATE UNIQUE INDEX IF NOT EXISTS {{name}}_current_all_rev_id_idx ON {{namespace}}{{name}}_current_all (rev_id);
-CREATE UNIQUE INDEX IF NOT EXISTS {{name}}_current_all_ext_uid_idx ON {{namespace}}{{name}}_current_all (ext_uid);
-CREATE UNIQUE INDEX IF NOT EXISTS {{name}}_current_all_deleted_idx ON {{namespace}}{{name}}_current_all (deleted);
+CREATE UNIQUE INDEX IF NOT EXISTS {{name}}_current_all_mview_rev_id_idx ON {{namespace}}{{name}}_current_all_mview (rev_id);
+CREATE UNIQUE INDEX IF NOT EXISTS {{name}}_current_all_mview_ext_uid_idx ON {{namespace}}{{name}}_current_all_mview (ext_uid);
+CREATE INDEX IF NOT EXISTS {{name}}_current_all_mview_deleted_idx ON {{namespace}}{{name}}_current_all_mview (deleted);
 {{#if extIdType}}
 {{#if storeSource}}
 -- Cannot be unique because this will cause issues with ON CONFLICT loading (as long as the uid is correctly formed, the PK will prevent duplicates)
-CREATE INDEX IF NOT EXISTS {{name}}_current_all_source_id_ext_id_idx ON {{namespace}}{{name}}_current_all (source_id, ext_id);
+CREATE INDEX IF NOT EXISTS {{name}}_current_all_mview_source_id_ext_id_idx ON {{namespace}}{{name}}_current_all_mview (source_id, ext_id);
 {{else}}
 -- Cannot be unique because this will cause issues with ON CONFLICT loading (as long as the uid is correctly formed, the PK will prevent duplicates)
-CREATE INDEX IF NOT EXISTS {{name}}_current_all_ext_id_idx ON {{namespace}}{{name}}_current_all (ext_id);
+CREATE INDEX IF NOT EXISTS {{name}}_current_all_mview_ext_id_idx ON {{namespace}}{{name}}_current_all_mview (ext_id);
 {{/if}}
 {{/if}}
 
 -- Update date commonly queried for chained updates
-CREATE INDEX IF NOT EXISTS {{name}}_current_all_update_date_idx ON {{namespace}}{{name}}_current_all (update_date);
+CREATE INDEX IF NOT EXISTS {{name}}_current_all_mview_update_date_idx ON {{namespace}}{{name}}_current_all_mview (update_date);
 
 -- Custom field indexes
 {{~#each extractedFields}}{{#if this.index}}
-CREATE {{#if this.unique}}UNIQUE {{/if}}INDEX IF NOT EXISTS {{../name}}_current_all_{{@key}}_idx ON {{../namespace}}{{../name}}_current_all ({{@key}});
+CREATE {{#if this.unique}}UNIQUE {{/if}}INDEX IF NOT EXISTS {{../name}}_current_all_mview_{{@key}}_idx ON {{../namespace}}{{../name}}_current_all_mview ({{@key}});
 {{/if}}{{/each}}
 {{~#each indexes}}
-CREATE {{#if this.unique}}UNIQUE {{/if}}INDEX IF NOT EXISTS {{../name}}_current_all_{{@key}}_idx ON {{../namespace}}{{../name}}_current_all {{this.definition}};{{#if this.comment}} -- {{this.comment}}{{/if}}
+CREATE {{#if this.unique}}UNIQUE {{/if}}INDEX IF NOT EXISTS {{../name}}_current_all_mview_{{@key}}_idx ON {{../namespace}}{{../name}}_current_all_mview {{this.definition}};{{#if this.comment}} -- {{this.comment}}{{/if}}
 {{/each}}
-
-{{else}}
---
--- Compatability view of current_view for consistency
---
-CREATE OR REPLACE VIEW {{namespace}}{{name}}_current_all AS
-SELECT * FROM {{namespace}}{{name}}_current_all_view;
 {{/if}}
 
 --
--- View of current_all without deleted items and without deleted flag
+-- Current-All view (need with clause so there is no prefix on the B columns)
+--
+{{#if materializeView}}
+CREATE OR REPLACE VIEW {{namespace}}{{name}}_current_all AS
+  WITH a AS (
+    SELECT a.*,
+           b.data_rev, b.raw_data, b.raw_delta, b.raw_revert, b.fetch_date, b.ext_create_date, b.ext_update_date, b.create_date
+      FROM {{namespace}}{{name}}_current_all_mview a
+      JOIN {{namespace}}{{name}}_rev b ON a.rev_id = b.rev_id
+  )
+  SELECT a.*
+{{~#each extractedFields}}{{#if this.definition}}{{#if this.doNotMaterialize}}
+      , {{this.definition}} AS {{@key}} {{#if this.comment}}-- {{this.comment}}{{/if}}
+{{/if}}{{/if}}{{/each}}
+  FROM a;
+{{else}}
+CREATE OR REPLACE VIEW {{namespace}}{{name}}_current_all AS
+    SELECT * FROM {{namespace}}{{name}}_current_all_mview;
+{{/if}}
+
+--
+-- Current view
 --
 CREATE OR REPLACE VIEW {{namespace}}{{name}}_current AS
-SELECT rev_id,
-       ext_uid,
-       {{#if storeSource}}source_id,{{/if}}
-       {{#if extIdType}}ext_id,{{/if}}
-       -- Begin custom fields
-{{~#each extractedFields}}{{#if this.definition}}
-      {{@key}},
-{{/if}}{{/each}}
-       update_date
-  FROM {{namespace}}{{name}}_current_all
- WHERE NOT deleted;
-
---
--- View of current data with the revision data (including raw data) added in
---
-CREATE OR REPLACE VIEW {{namespace}}{{name}}_current_all_with_rev AS
-SELECT a.*,
-       b.data_rev, b.raw_data, b.raw_delta, b.raw_revert, b.fetch_date, b.ext_create_date, b.ext_update_date, b.create_date
-  FROM {{namespace}}{{name}}_current_all a
-  JOIN {{namespace}}{{name}}_rev b ON a.rev_id = b.rev_id;
-
-CREATE OR REPLACE VIEW {{namespace}}{{name}}_current_with_rev AS
-SELECT a.*,
-       b.data_rev, b.raw_data, b.raw_delta, b.raw_revert, b.fetch_date, b.ext_create_date, b.ext_update_date, b.create_date
-  FROM {{namespace}}{{name}}_current a
-  JOIN {{namespace}}{{name}}_rev b ON a.rev_id = b.rev_id;
+{{#if materializeView}}
+  WITH a AS (
+    SELECT a.*,
+           b.data_rev, b.raw_data, b.raw_delta, b.raw_revert, b.fetch_date, b.ext_create_date, b.ext_update_date, b.create_date
+      FROM {{namespace}}{{name}}_current_all_mview a
+      JOIN {{namespace}}{{name}}_rev b ON a.rev_id = b.rev_id
+     WHERE NOT a.deleted
+  )
+  SELECT a.*
+{{~#each extractedFields}}{{#if this.definition}}{{#if this.doNotMaterialize}}
+      , {{this.definition}} AS {{@key}} {{#if this.comment}}-- {{this.comment}}{{/if}}
+{{/if}}{{/if}}{{/each}}
+  FROM a;
+{{else}}
+    SELECT * FROM {{namespace}}{{name}}_current_all_mview WHERE NOT deleted;
+{{/if}}
 
 --
 -- Refresh the materialized view

--- a/src/views/partials/drop.hbs
+++ b/src/views/partials/drop.hbs
@@ -11,16 +11,12 @@
 {{/each}}{{/if}}
 
 {{#if ../includeTransient}}DROP PROCEDURE IF EXISTS {{namespace}}{{name}}_current_refresh;{{/if}}
-{{#if ../includeTransient}}DROP VIEW IF EXISTS {{namespace}}{{name}}_current_with_rev;{{/if}}
 {{#if ../includeTransient}}DROP VIEW IF EXISTS {{namespace}}{{name}}_current;{{/if}}
-{{#if ../includeTransient}}DROP VIEW IF EXISTS {{namespace}}{{name}}_current_all_with_rev;{{/if}}
-{{#if ../includeTransient}}DROP {{#if materializeView}}MATERIALIZED {{/if}}VIEW IF EXISTS {{namespace}}{{name}}_current_all;{{/if}}
-{{#if ../includeTransient}}DROP VIEW IF EXISTS {{namespace}}{{name}}_current_all_view;{{/if}}
+{{#if ../includeTransient}}DROP VIEW IF EXISTS {{namespace}}{{name}}_current_all;{{/if}}
+{{#if ../includeTransient}}DROP {{#if materializeView}}MATERIALIZED {{/if}}VIEW IF EXISTS {{namespace}}{{name}}_current_all_mview;{{/if}}
 
 {{#if ../includeTransient}}DROP PROCEDURE IF EXISTS {{namespace}}{{name}}_rev_trim;{{/if}}
 {{#if ../includeTransient}}DROP PROCEDURE IF EXISTS {{namespace}}{{name}}_rev_load;{{/if}}
-{{#if ../includeTransient}}DROP VIEW IF EXISTS {{namespace}}{{name}}_rev_current;{{/if}}
-{{#if ../includeTransient}}DROP VIEW IF EXISTS {{namespace}}{{name}}_rev_current_all;{{/if}}
 {{#if ../includePersistent}}DROP TABLE IF EXISTS {{namespace}}{{name}}_rev;{{/if}}
 
 {{#if ../includeTransient}}DROP PROCEDURE IF EXISTS {{namespace}}{{name}}_raw_trim;{{/if}}

--- a/src/views/partials/grants.hbs
+++ b/src/views/partials/grants.hbs
@@ -3,13 +3,9 @@
 GRANT EXECUTE ON FUNCTION {{namespace}}{{name}}_default_source_id TO {{viewers}};
 GRANT SELECT ON {{namespace}}{{name}}_raw TO {{viewers}};
 GRANT SELECT ON {{namespace}}{{name}}_rev TO {{viewers}};
-GRANT SELECT ON {{namespace}}{{name}}_rev_current_all TO {{viewers}};
-GRANT SELECT ON {{namespace}}{{name}}_rev_current TO {{viewers}};
-GRANT SELECT ON {{namespace}}{{name}}_current_all_view TO {{viewers}};
+GRANT SELECT ON {{namespace}}{{name}}_current_all_mview TO {{viewers}};
 GRANT SELECT ON {{namespace}}{{name}}_current_all TO {{viewers}};
-GRANT SELECT ON {{namespace}}{{name}}_current_all_with_rev TO {{viewers}};
 GRANT SELECT ON {{namespace}}{{name}}_current TO {{viewers}};
-GRANT SELECT ON {{namespace}}{{name}}_current_with_rev TO {{viewers}};
 GRANT SELECT ON {{namespace}}{{name}}_updated TO {{viewers}};
 {{#each extraUpdated}}
 GRANT EXECUTE ON FUNCTION {{../namespace}}{{this}}_default_source_id TO {{../viewers}};
@@ -23,13 +19,9 @@ GRANT SELECT ON {{../namespace}}{{this}}_updated TO {{../viewers}};
 GRANT EXECUTE ON FUNCTION {{namespace}}{{name}}_default_source_id TO {{updaters}};
 GRANT SELECT ON {{namespace}}{{name}}_raw TO {{updaters}};
 GRANT SELECT ON {{namespace}}{{name}}_rev TO {{updaters}};
-GRANT SELECT ON {{namespace}}{{name}}_rev_current_all TO {{updaters}};
-GRANT SELECT ON {{namespace}}{{name}}_rev_current TO {{updaters}};
-GRANT SELECT ON {{namespace}}{{name}}_current_all_view TO {{updaters}};
+GRANT SELECT ON {{namespace}}{{name}}_current_all_mview TO {{updaters}};
 GRANT SELECT ON {{namespace}}{{name}}_current_all TO {{updaters}};
-GRANT SELECT ON {{namespace}}{{name}}_current_all_with_rev TO {{updaters}};
 GRANT SELECT ON {{namespace}}{{name}}_current TO {{updaters}};
-GRANT SELECT ON {{namespace}}{{name}}_current_with_rev TO {{updaters}};
 GRANT SELECT ON {{namespace}}{{name}}_updated TO {{updaters}};
 {{#each extraUpdated}}
 GRANT SELECT ON {{../namespace}}{{this}}_updated TO {{../updaters}};

--- a/src/views/partials/rev.hbs
+++ b/src/views/partials/rev.hbs
@@ -42,19 +42,6 @@ CREATE INDEX IF NOT EXISTS {{name}}_rev_current_deleted_idx ON {{namespace}}{{na
 CREATE INDEX IF NOT EXISTS {{name}}_rev_ext_uid_current_idx ON {{namespace}}{{name}}_rev (ext_uid) WHERE current;
 
 --
--- View of current, not deleted revisions
---
-CREATE OR REPLACE VIEW {{namespace}}{{name}}_rev_current_all AS
-SELECT *
-  FROM {{namespace}}{{name}}_rev
- WHERE current;
-
-CREATE OR REPLACE VIEW {{namespace}}{{name}}_rev_current AS
-SELECT *
-  FROM {{namespace}}{{name}}_rev
- WHERE current AND NOT deleted;
-
---
 -- This procedure looks for updated _raw records and loads them into _rev
 --
 -- THE APPLICATION IS RESPONSIBLE TO ENSURE THAT ONLY ONE EXECUTION OF THIS FUNCTION OCCURS AT A TIME!


### PR DESCRIPTION
- 2022-08-09: v0.3.0
  - Removed rev_current and rev_current_all views
  - Changed _current_all_view to current_all_mview
    -  When not materialized due to config, this includes the _with_rev views to limit joins across views
  - Removed _with_rev views and rolled rev columns in to base views
  - Syntax fixes for materialized views
  - Added doNotMaterialize flag for extracted fields to omit them from the materialized table to save space
